### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     name: Tag release
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Tag version
         uses: wendbv/calver-tag-action@main
         with:


### PR DESCRIPTION
## SHA Pinning — automated PR

This PR pins all GitHub Actions workflow steps to immutable commit SHAs.

### What changed

All mutable GitHub Actions tag references (e.g. `@v3`) have been replaced with immutable commit SHA pins plus a version comment, for example:

```yaml
# before
- uses: actions/checkout@v4
# after
- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Dependabot will keep the SHA pins up-to-date – it's natively [supported by GitHub](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/).

### Why

A mutable tag can be silently re-pointed to a malicious commit. SHA pins guarantee exactly which code runs in CI.  
See: [tj-actions/changed-files incident (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)

### Review checklist

- [ ] Spot-check a few SHA pins against the upstream action repo
- [ ] Verify CI still passes after merge
- [ ] **Merge into `main`**

### ⚠️ Actions requiring manual review

The following actions could **not** be pinned automatically and need manual attention:

| Action | Location |
|---|---|
| `wendbv/calver-tag-action@main` | `.github/workflows/main.yml:11` |

These refs (e.g. `@main`, `@master`, `@release/v1`) could not be resolved to a commit SHA by pinact. Please pin them manually or add a comment justifying why they are left unpinned.
